### PR TITLE
 🩹 fix [#4] : 라우팅 경로 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,59 +16,59 @@ spring:
         - id: user-service
           uri: lb://user-service
           predicates:
-            - Path=/api/v1/users/*
+            - Path=/api/v1/users/**
 
         - id: auth-service
           uri: lb://auth-service
           predicates:
-            - Path=/api/v1/auth/*
+            - Path=/api/v1/auth/**
 
         - id: order-service
           uri: lb://order-service
           predicates:
-            - Path=/api/v1/orders/*
+            - Path=/api/v1/orders/**
 
         - id: auction-product-service
           uri: lb://auction-service
           predicates:
-            - Path=/api/v1/auction-products/*
+            - Path=/api/v1/auction-products/**
 
         - id: auction-service
           uri: lb://auction-service
           predicates:
-            - Path=/api/v1/auctions/*
+            - Path=/api/v1/auctions/**
 
         - id: coupon-service
           uri: lb://coupon-service
           predicates:
-            - Path=/api/v1/coupons/*
+            - Path=/api/v1/coupons/**
 
         - id: user-coupon-service
           uri: lb://coupon-service
           predicates:
-            - Path=/api/v1/user-coupons/*
+            - Path=/api/v1/user-coupons/**
 
         - id: preuser-service
           uri: lb://preuser-service
           predicates:
-            - Path=/api/v1/preusers/*
+            - Path=/api/v1/preusers/**
 
         - id: preuser-product-service
           uri: lb://preuser-service
           predicates:
-            - Path=/api/v1/preuser-products/*
+            - Path=/api/v1/preuser-products/**
 
         - id: product-service
           uri: lb://product-service
           predicates:
-            - Path=/api/v1/products/*
+            - Path=/api/v1/products/**
 
         - id: limited-service
           uri: lb://limited-service
           predicates:
-            - Path=/api/v1/limited-events/*
+            - Path=/api/v1/limited-events/**
 
         - id: limited-products-service
           uri: lb://limited-service
           predicates:
-            - Path=/api/v1/limited-products/*
+            - Path=/api/v1/limited-products/**


### PR DESCRIPTION


## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [x] 버그 수정
* [ ] 리팩토링
* [x] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
    * 라우팅 경로 버그 수정

* **세부 내용**
   - 라우팅 경로 뒤에 *이 하나만 존재한다면 / 뒤로 한 단계만 허용합니다
   - 예를 들어 /v1/users/aaa/bbb 라는경로가 있다면 라우팅 해주지 않습니다
   - /v1/users/aaa 까지만 라우팅 해줍니다
   - *을 하나만 붙이는 것이 아닌 **로 허용하여 뒤에 몇단계가 오든 허용하도록 설정하였습니다
   - /v1/users, v1/users/aaa/bbb 등 user-service의 경로와 맞게 매칭 성공 확인 하였습니다